### PR TITLE
Add extra content headers from Croquemort

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Current (in progress)
 
-- Expose new HTTP headers related to content (`content-type`, `content-length`, `charset`, `content-md5`, `content-disposition`)
+- Expose new HTTP headers related to content (`content-type`, `content-length`, `charset`, `content-md5`, `content-disposition`) [#133](https://github.com/opendatateam/udata-croquemort/pull/133)
 
 ## 2.0.0 (2020-03-11)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Current (in progress)
 
-- Expose new HTTP headers related to content (`content-type`, `content-length`, `charset`, `content-md5`)
+- Expose new HTTP headers related to content (`content-type`, `content-length`, `charset`, `content-md5`, `content-disposition`)
 
 ## 2.0.0 (2020-03-11)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Current (in progress)
 
-- Nothing yet
+- Expose new HTTP headers related to content (`content-type`, `content-length`, `charset`, `content-md5`)
 
 ## 2.0.0 (2020-03-11)
 

--- a/udata_croquemort/checker.py
+++ b/udata_croquemort/checker.py
@@ -36,7 +36,7 @@ class CroquemortLinkChecker(object):
                 'content-type', 'content-length', 'content-md5', 'charset',
                 'content-disposition'
             ]:
-                result[f"check-headers:{header}"] = response.get(header)
+                result[f"check:headers:{header}"] = response.get(header)
 
             return result
 
@@ -51,18 +51,18 @@ class CroquemortLinkChecker(object):
         dict or None
             The formatted response from the linkchecker, like so:
             {
-                'check:url': 'https://example.com',
-                'check:status': 200,
-                'check:available': True,
-                'check:date': datetime.datetime(2017, 9, 4, 11, 13, 8, 888288),
-                'content-type': 'text/csv',
-                'content-length': '245436',
-                'content-md5': 'acbd18db4cc2f85cedef654fccc4a4d8',
-                'charset': 'utf-8',
+              'check:url': 'https://example.com',
+              'check:status': 200,
+              'check:available': True,
+              'check:date': datetime.datetime(2017, 9, 4, 11, 13, 8, 888288),
+              'check:headers:content-type': 'text/csv',
+              'check:headers:content-length': '245436',
+              'check:headers:content-md5': 'acbd18db4cc2f85cedef654fccc4a4d8',
+              'check:headers:charset': 'utf-8',
             }
             Or in case of failure (in udata-croquemort, not croquemort):
             {
-                'check:error': 'Something went terribly wrong.'
+              'check:error': 'Something went terribly wrong.'
             }
             Or in case of failure in croquemort:
             None

--- a/udata_croquemort/checker.py
+++ b/udata_croquemort/checker.py
@@ -35,7 +35,7 @@ class CroquemortLinkChecker(object):
             for header in [
                 'content-type', 'content-length', 'content-md5', 'charset'
             ]:
-                result[f"metadata:{header}"] = response.get(header)
+                result[f"check-headers:{header}"] = response.get(header)
 
             return result
 

--- a/udata_croquemort/checker.py
+++ b/udata_croquemort/checker.py
@@ -24,12 +24,20 @@ class CroquemortLinkChecker(object):
             check_date = response.get('updated')
             if check_date:
                 check_date = dateutil.parser.parse(response.get('updated'))
-            return {
+
+            result = {
                 'check:url': response.get('checked-url'),
                 'check:status': status,
                 'check:available': status and status >= 200 and status < 400,
                 'check:date': check_date,
             }
+
+            for header in [
+                'content-type', 'content-length', 'content-md5', 'charset'
+            ]:
+                result[f"metadata:{header}"] = response.get(header)
+
+            return result
 
     def check(self, resource):
         """

--- a/udata_croquemort/checker.py
+++ b/udata_croquemort/checker.py
@@ -33,7 +33,8 @@ class CroquemortLinkChecker(object):
             }
 
             for header in [
-                'content-type', 'content-length', 'content-md5', 'charset'
+                'content-type', 'content-length', 'content-md5', 'charset',
+                'content-disposition'
             ]:
                 result[f"check-headers:{header}"] = response.get(header)
 

--- a/udata_croquemort/checker.py
+++ b/udata_croquemort/checker.py
@@ -59,6 +59,7 @@ class CroquemortLinkChecker(object):
               'check:headers:content-length': '245436',
               'check:headers:content-md5': 'acbd18db4cc2f85cedef654fccc4a4d8',
               'check:headers:charset': 'utf-8',
+              'check:headers:content-disposition': 'inline'
             }
             Or in case of failure (in udata-croquemort, not croquemort):
             {

--- a/udata_croquemort/checker.py
+++ b/udata_croquemort/checker.py
@@ -54,6 +54,10 @@ class CroquemortLinkChecker(object):
                 'check:status': 200,
                 'check:available': True,
                 'check:date': datetime.datetime(2017, 9, 4, 11, 13, 8, 888288),
+                'content-type': 'text/csv',
+                'content-length': '245436',
+                'content-md5': 'acbd18db4cc2f85cedef654fccc4a4d8',
+                'charset': 'utf-8',
             }
             Or in case of failure (in udata-croquemort, not croquemort):
             {

--- a/udata_croquemort/tests.py
+++ b/udata_croquemort/tests.py
@@ -92,9 +92,9 @@ class UdataCroquemortTest:
             assert res['check:status'] == test_case['status']
             assert res['check:available'] == test_case['available']
             assert isinstance(res['check:date'], datetime)
-            assert res['metadata:content-type'] == 'text/html'
-            assert res['metadata:content-length'] == '2512124'
-            assert res['metadata:charset'] == 'utf-8'
+            assert res['check-headers:content-type'] == 'text/html'
+            assert res['check-headers:content-length'] == '2512124'
+            assert res['check-headers:charset'] == 'utf-8'
 
     def test_returned_metadata_w_missing_updated(self, httpretty):
         url = self.resource.url

--- a/udata_croquemort/tests.py
+++ b/udata_croquemort/tests.py
@@ -92,9 +92,9 @@ class UdataCroquemortTest:
             assert res['check:status'] == test_case['status']
             assert res['check:available'] == test_case['available']
             assert isinstance(res['check:date'], datetime)
-            assert res['check-headers:content-type'] == 'text/html'
-            assert res['check-headers:content-length'] == '2512124'
-            assert res['check-headers:charset'] == 'utf-8'
+            assert res['check:headers:content-type'] == 'text/html'
+            assert res['check:headers:content-length'] == '2512124'
+            assert res['check:headers:charset'] == 'utf-8'
 
     def test_returned_metadata_w_missing_updated(self, httpretty):
         url = self.resource.url

--- a/udata_croquemort/tests.py
+++ b/udata_croquemort/tests.py
@@ -80,7 +80,9 @@ class UdataCroquemortTest:
             {'status': 503, 'available': False},
         ]
         metadata = {
-            'content-type': 'text/html; charset=utf-8',
+            'content-type': 'text/html',
+            'content-length': '2512124',
+            'charset': 'utf-8'
         }
         for test_case in test_cases:
             metadata['final-status-code'] = test_case['status']
@@ -90,11 +92,14 @@ class UdataCroquemortTest:
             assert res['check:status'] == test_case['status']
             assert res['check:available'] == test_case['available']
             assert isinstance(res['check:date'], datetime)
+            assert res['metadata:content-type'] == 'text/html'
+            assert res['metadata:content-length'] == '2512124'
+            assert res['metadata:charset'] == 'utf-8'
 
     def test_returned_metadata_w_missing_updated(self, httpretty):
         url = self.resource.url
         metadata = {
-            'content-type': 'text/html; charset=utf-8',
+            'content-type': 'text/html',
             'final-status-code': 200,
             'available': True
         }


### PR DESCRIPTION
Some content headers would be useful to have to update resources' metadata on udata.

Content-Type and Content-Length could be used to set the MIME type and the filesize of resources, enabling a larger usage of CSVAPI for remote resources.