### PR TITLE
Handle empty values for HTTP headers

### DIFF
--- a/udata_croquemort/checker.py
+++ b/udata_croquemort/checker.py
@@ -36,7 +36,12 @@ class CroquemortLinkChecker(object):
                 'content-type', 'content-length', 'content-md5', 'charset',
                 'content-disposition'
             ]:
-                result[f"check:headers:{header}"] = response.get(header)
+                value = response.get(header, '')
+                if len(value) > 0:
+                    try:
+                        result[f"check:headers:{header}"] = int(value)
+                    except ValueError:
+                        result[f"check:headers:{header}"] = value
 
             return result
 
@@ -56,7 +61,7 @@ class CroquemortLinkChecker(object):
               'check:available': True,
               'check:date': datetime.datetime(2017, 9, 4, 11, 13, 8, 888288),
               'check:headers:content-type': 'text/csv',
-              'check:headers:content-length': '245436',
+              'check:headers:content-length': 245436,
               'check:headers:content-md5': 'acbd18db4cc2f85cedef654fccc4a4d8',
               'check:headers:charset': 'utf-8',
               'check:headers:content-disposition': 'inline'

--- a/udata_croquemort/checker.py
+++ b/udata_croquemort/checker.py
@@ -36,7 +36,7 @@ class CroquemortLinkChecker(object):
                 'content-type', 'content-length', 'content-md5', 'charset',
                 'content-disposition'
             ]:
-                value = response.get(header, '')
+                value = str(response.get(header, '') or '')
                 if len(value) > 0:
                     try:
                         result[f"check:headers:{header}"] = int(value)

--- a/udata_croquemort/tests.py
+++ b/udata_croquemort/tests.py
@@ -82,7 +82,8 @@ class UdataCroquemortTest:
         metadata = {
             'content-type': 'text/html',
             'content-length': '2512124',
-            'charset': 'utf-8'
+            'charset': 'utf-8',
+            'content-md5': None,
         }
         for test_case in test_cases:
             metadata['final-status-code'] = test_case['status']
@@ -93,8 +94,9 @@ class UdataCroquemortTest:
             assert res['check:available'] == test_case['available']
             assert isinstance(res['check:date'], datetime)
             assert res['check:headers:content-type'] == 'text/html'
-            assert res['check:headers:content-length'] == '2512124'
+            assert res['check:headers:content-length'] == 2512124
             assert res['check:headers:charset'] == 'utf-8'
+            assert 'check:headers:content-md5' not in res
 
     def test_returned_metadata_w_missing_updated(self, httpretty):
         url = self.resource.url


### PR DESCRIPTION
Follow up of #133
- Add header only if value is not `None` and non empty
- Cast to int if possible (important for `content-length`)